### PR TITLE
Исправление предупреждения об отсутствии водяного знака

### DIFF
--- a/language/en-GB/plg_jshoppingadmin_wt_on_fly_image_handler.ini
+++ b/language/en-GB/plg_jshoppingadmin_wt_on_fly_image_handler.ini
@@ -35,3 +35,6 @@ PLG_WT_ON_FLY_IMAGE_HANDLER_WATERMARK_POS_DESC = "Select the position in the ima
 PLG_WT_ON_FLY_IMAGE_HANDLER_WATERMARK_PADDING_LABEL = "Watermark Margins"
 PLG_WT_ON_FLY_IMAGE_HANDLER_WATERMARK_PADDING_DESC = "The margins of the watermark from the edges of the image in pixels."
 PLG_WT_ON_FLY_IMAGE_HANDLER_WATERMARK_OPACITY_LABEL = "Watermark opacity"
+
+PLG_WT_ON_FLY_IMAGE_HANDLER_NO_WATERMARK_SPECIFIED_WARNING = "WT On fly image handler: There is no watermark file specified"
+PLG_WT_ON_FLY_IMAGE_HANDLER_NO_WATERMARK_FOUND_ERROR = "WT On fly image handler: Watermark file not found in \"%s\""

--- a/language/ru-RU/plg_jshoppingadmin_wt_on_fly_image_handler.ini
+++ b/language/ru-RU/plg_jshoppingadmin_wt_on_fly_image_handler.ini
@@ -34,3 +34,6 @@ PLG_WT_ON_FLY_IMAGE_HANDLER_WATERMARK_POS_DESC = "Выбор позиции на
 PLG_WT_ON_FLY_IMAGE_HANDLER_WATERMARK_PADDING_LABEL = "Отступы водяного знака"
 PLG_WT_ON_FLY_IMAGE_HANDLER_WATERMARK_PADDING_DESC = "Отступы водяного знака от краев изображения в пикселях."
 PLG_WT_ON_FLY_IMAGE_HANDLER_WATERMARK_OPACITY_LABEL = "Прозрачность водяного знака"
+
+PLG_WT_ON_FLY_IMAGE_HANDLER_NO_WATERMARK_SPECIFIED_WARNING = "WT On fly image handler: Укажите файл водяного знака в настройках плагина!"
+PLG_WT_ON_FLY_IMAGE_HANDLER_NO_WATERMARK_FOUND_ERROR = "WT On fly image handler: Файл водяного знака не найден в \"%s\""

--- a/language/ru-RU/plg_jshoppingadmin_wt_on_fly_image_handler.ini
+++ b/language/ru-RU/plg_jshoppingadmin_wt_on_fly_image_handler.ini
@@ -35,5 +35,5 @@ PLG_WT_ON_FLY_IMAGE_HANDLER_WATERMARK_PADDING_LABEL = "Отступы водян
 PLG_WT_ON_FLY_IMAGE_HANDLER_WATERMARK_PADDING_DESC = "Отступы водяного знака от краев изображения в пикселях."
 PLG_WT_ON_FLY_IMAGE_HANDLER_WATERMARK_OPACITY_LABEL = "Прозрачность водяного знака"
 
-PLG_WT_ON_FLY_IMAGE_HANDLER_NO_WATERMARK_SPECIFIED_WARNING = "WT On fly image handler: Укажите файл водяного знака в настройках плагина!"
+PLG_WT_ON_FLY_IMAGE_HANDLER_NO_WATERMARK_SPECIFIED_WARNING = "WT On fly image handler: Файл водяного знака не указан в настройках плагина"
 PLG_WT_ON_FLY_IMAGE_HANDLER_NO_WATERMARK_FOUND_ERROR = "WT On fly image handler: Файл водяного знака не найден в \"%s\""

--- a/src/Extension/Wt_on_fly_image_handler.php
+++ b/src/Extension/Wt_on_fly_image_handler.php
@@ -296,6 +296,13 @@ class Wt_on_fly_image_handler extends CMSPlugin implements SubscriberInterface
 	 */
 	public function placeWatermark(Image $image): Image
 	{
+        $useWatermark = $this->params->get('watermark', 0);
+
+        if (empty($useWatermark))
+        {
+            return $image;
+        }
+
 		$fileWatermark = $this->params->get('watermarkfile', '');
 
 		if (empty($fileWatermark))

--- a/src/Extension/Wt_on_fly_image_handler.php
+++ b/src/Extension/Wt_on_fly_image_handler.php
@@ -307,7 +307,7 @@ class Wt_on_fly_image_handler extends CMSPlugin implements SubscriberInterface
 
 		if (empty($fileWatermark))
 		{
-			$this->getApplication()->enqueueMessage('WT On fly image handler: there is no watermark file specified');
+			$this->getApplication()->enqueueMessage(Text::_('PLG_WT_ON_FLY_IMAGE_HANDLER_NO_WATERMARK_SPECIFIED_WARNING'), 'warning');
 
 			return $image;
 		}
@@ -347,7 +347,7 @@ class Wt_on_fly_image_handler extends CMSPlugin implements SubscriberInterface
 			return $image;
 
 		}
-		$this->getApplication()->enqueueMessage('WT On fly image handler: watermark file not found in ' . $fileWatermark);
+		$this->getApplication()->enqueueMessage(Text::_('PLG_WT_ON_FLY_IMAGE_HANDLER_NO_WATERMARK_FOUND_ERROR', $fileWatermark), 'error');
 
 		return $image;
 

--- a/src/Extension/Wt_on_fly_image_handler.php
+++ b/src/Extension/Wt_on_fly_image_handler.php
@@ -303,6 +303,7 @@ class Wt_on_fly_image_handler extends CMSPlugin implements SubscriberInterface
             return $image;
         }
 
+        $this->getApplication()->getLanguage()->load('plg_' . $this->_type . '_' . $this->_name, JPATH_ADMINISTRATOR);
 		$fileWatermark = $this->params->get('watermarkfile', '');
 
 		if (empty($fileWatermark))
@@ -347,7 +348,7 @@ class Wt_on_fly_image_handler extends CMSPlugin implements SubscriberInterface
 			return $image;
 
 		}
-		$this->getApplication()->enqueueMessage(Text::_('PLG_WT_ON_FLY_IMAGE_HANDLER_NO_WATERMARK_FOUND_ERROR', $fileWatermark), 'error');
+		$this->getApplication()->enqueueMessage(Text::sprintf('PLG_WT_ON_FLY_IMAGE_HANDLER_NO_WATERMARK_FOUND_ERROR', $fileWatermark), 'error');
 
 		return $image;
 


### PR DESCRIPTION
1. Исправление предупреждения об отсутствии водяного знака если он выключен в настройках плагина.
2. Локализация системных сообщений плагина, теперь они отображаются на уровнях "warning"/"error"